### PR TITLE
Added Imagemagick

### DIFF
--- a/ansible/roles/init/tasks/main.yml
+++ b/ansible/roles/init/tasks/main.yml
@@ -45,6 +45,7 @@
     - libxrender1
     - build-essential
     - mydumper
+    - imagemagick
 
 - name: Install phantomjs
   become: yes


### PR DESCRIPTION
Imagemagick wird benötigt, um im PV-Check-Backend automatisiert die PDF-Erzeugung zu testen.

Tickets:
- keine
